### PR TITLE
PE-49 | Implemented RootPage to Handle SharedPreferences()

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,24 +1,9 @@
-import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
-import 'package:project_eureka_flutter/screens/login_page.dart';
-import 'package:shared_preferences/shared_preferences.dart';
-import 'package:project_eureka_flutter/screens/onboarding.dart';
+import 'package:project_eureka_flutter/screens/root_page.dart';
 
-//first time login checker
-int initScreen;
+void main() => runApp(ProjectEureka());
 
-Future<void> main() async {
-  WidgetsFlutterBinding.ensureInitialized();
-  await Firebase.initializeApp();
-  SharedPreferences prefs = await SharedPreferences.getInstance();
-  initScreen = await prefs.getInt("initScreen");
-  await prefs.setInt("initScreen", 1); //after first launch set to 1
-  print(
-      'initScreen ${initScreen}'); // printout to see how many times app was launched
-  runApp(MyApp());
-}
-
-class MyApp extends StatelessWidget {
+class ProjectEureka extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final appTitle = 'Project Eureka';
@@ -28,13 +13,9 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         primarySwatch: Colors.blue,
         visualDensity: VisualDensity.adaptivePlatformDensity,
-      ), // check if it's the first launch of app
-      initialRoute: initScreen == 0 || initScreen == null ? "first" : "/",
-      routes: {
-        '/': (context) => LoginPage(),
-        "first": (context) => Onboarding(),
-      },
+      ),
       debugShowCheckedModeBanner: false,
+      home: RootPage(),
     );
   }
 }

--- a/lib/screens/login_page.dart
+++ b/lib/screens/login_page.dart
@@ -63,11 +63,12 @@ class _LoginPageState extends State<LoginPage> {
       _googleAuth.signInWithGoogle().then(
         (result) {
           if (result != null) {
-            Navigator.push(
+            Navigator.pushAndRemoveUntil(
               context,
               MaterialPageRoute(
                 builder: (context) => Home(),
               ),
+              (Route<void> route) => false,
             );
           }
         },
@@ -86,11 +87,12 @@ class _LoginPageState extends State<LoginPage> {
     try {
       await _emailAuth.signIn(email, password);
 
-      Navigator.push(
+      Navigator.pushAndRemoveUntil(
         context,
         MaterialPageRoute(
           builder: (context) => Home(),
         ),
+        (Route<void> route) => false,
       );
       setState(() {
         showSpinner = false;

--- a/lib/screens/onboarding.dart
+++ b/lib/screens/onboarding.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:introduction_screen/introduction_screen.dart';
-import 'package:project_eureka_flutter/screens/login_page.dart';
+import 'package:project_eureka_flutter/screens/root_page.dart';
+import 'package:project_eureka_flutter/services/shared_preferences_helper.dart';
 
 class Onboarding extends StatefulWidget {
   @override
@@ -15,7 +16,6 @@ class _OnboardingState extends State<Onboarding> {
           title: 'Welcome to Eureka!',
           body:
               'Eureka is a platform for peers to help each other by answering questions \n\n Everyone can help and even get paid for help!',
-          footer: Text(''),
           decoration: const PageDecoration(
               //pageColor: Color(0xfffdfafc),
               )),
@@ -26,7 +26,6 @@ class _OnboardingState extends State<Onboarding> {
           body:
               'Eureka allows posting questions as on any regular forum, BUT also gives you an option of posting questions with an incentive \n\n'
               'Need answer ASAP? \n\n Try adding incentive to your question \n Paid questions get answers a lot faster!',
-          footer: Text(''),
           decoration: const PageDecoration(
               //pageColor: Color(0xffB9AEFB),
               )),
@@ -39,7 +38,6 @@ class _OnboardingState extends State<Onboarding> {
         decoration: const PageDecoration(
             //pageColor: Color(0xfffdfafc),
             ),
-        footer: Text(''),
       ),
       //-----------------------------------------------------------Privacy
       PageViewModel(
@@ -50,7 +48,6 @@ class _OnboardingState extends State<Onboarding> {
         decoration: const PageDecoration(
             //pageColor: Color(0xfffdfafc),
             ),
-        footer: Text(''),
       ),
       //-----------------------------------------------------------Categories
       PageViewModel(
@@ -61,7 +58,6 @@ class _OnboardingState extends State<Onboarding> {
         decoration: const PageDecoration(
           pageColor: Color(0xfffdfafc),
         ),
-        footer: Text(''),
       ),
       //-----------------------------------------------------------All set
       PageViewModel(
@@ -72,7 +68,6 @@ class _OnboardingState extends State<Onboarding> {
         decoration: const PageDecoration(
           pageColor: Color(0xff6DB8FF),
         ),
-        footer: Text(''),
       ),
     ];
   }
@@ -87,9 +82,19 @@ class _OnboardingState extends State<Onboarding> {
         showSkipButton: true,
         skip: Text('Skip'),
         done: Text('Got it'),
+        dotsDecorator: DotsDecorator(
+          size: const Size.square(10.0),
+          activeSize: const Size(20.0, 10.0),
+          color: Colors.black26,
+          spacing: const EdgeInsets.symmetric(horizontal: 3.0),
+          activeShape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(25.0),
+          ),
+        ),
         onDone: () {
+          SharedPreferencesHelper().setInitScreen(1);
           Navigator.push(
-              context, MaterialPageRoute(builder: (context) => LoginPage()));
+              context, MaterialPageRoute(builder: (context) => RootPage()));
         },
       ),
     );

--- a/lib/screens/root_page.dart
+++ b/lib/screens/root_page.dart
@@ -1,0 +1,62 @@
+import 'package:firebase_core/firebase_core.dart';
+import 'package:flutter/material.dart';
+import 'package:project_eureka_flutter/screens/home_page.dart';
+import 'package:project_eureka_flutter/screens/login_page.dart';
+import 'package:project_eureka_flutter/screens/onboarding.dart';
+import 'package:project_eureka_flutter/services/email_auth.dart';
+import 'package:project_eureka_flutter/services/shared_preferences_helper.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class RootPage extends StatefulWidget {
+  @override
+  _RootPageState createState() => _RootPageState();
+}
+
+class _RootPageState extends State<RootPage> {
+  SharedPreferences _prefs;
+
+  @override
+  void initState() {
+    _initState();
+    super.initState();
+  }
+
+  Future<void> _initState() async {
+    await Firebase.initializeApp();
+
+    _prefs = await SharedPreferences.getInstance();
+
+    /// checks if the app has seen the onboarding screen yet
+    /// if '1', they already have => go to Home/LoginPage instead.
+    if (SharedPreferencesHelper().getInitScreen(_prefs) == 1) {
+      /// checks to see if the user is signed in
+      /// if no user found => show Login, else show Home
+      if (EmailAuth().getCurrentUser() != null) {
+        pushAndRemoveUntil(Home());
+      } else {
+        pushAndRemoveUntil(LoginPage());
+      }
+    } else {
+      pushAndRemoveUntil(Onboarding());
+    }
+  }
+
+  Future<dynamic> pushAndRemoveUntil(Widget route) {
+    return Navigator.pushAndRemoveUntil(
+      context,
+      MaterialPageRoute(
+        builder: (context) => route,
+      ),
+      (Route<void> route) => false,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: CircularProgressIndicator(),
+      ),
+    );
+  }
+}

--- a/lib/screens/settings/settings_general.dart
+++ b/lib/screens/settings/settings_general.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/cupertino.dart';
+import 'package:project_eureka_flutter/services/shared_preferences_helper.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class SettingsGeneral extends StatefulWidget {
@@ -9,34 +10,27 @@ class SettingsGeneral extends StatefulWidget {
 
 /// This is the private State class that goes with MyStatefulWidget.
 class _SettingsGeneral extends State<SettingsGeneral> {
+  SharedPreferencesHelper sharedPreferencesHelper =
+      new SharedPreferencesHelper();
+
   // initialized three settings
   bool _darkMode = false;
   bool _emailNotification = false;
   bool _textNotification = false;
 
-  Future<bool> _getBoolValuesSF(String setting) async {
-    SharedPreferences prefs = await SharedPreferences.getInstance();
-    return prefs.getBool(setting) ?? false; // if setting doesn't exist yet, give false
-  }
-
-  void _switchSetting(String setting, bool value) async {
-    SharedPreferences prefs = await SharedPreferences.getInstance();
-    prefs.setBool(setting, value);
-  }
-
   // get initial values of the settings once coming to the settings page
   void _getValuesSettings() {
-    _getBoolValuesSF('darkMode').then((data) {
+    sharedPreferencesHelper.getSettings('darkMode').then((data) {
       setState(() {
         _darkMode = data;
       });
     });
-    _getBoolValuesSF('emailNotification').then((data) {
+    sharedPreferencesHelper.getSettings('emailNotification').then((data) {
       setState(() {
         _emailNotification = data;
       });
     });
-    _getBoolValuesSF('textNotification').then((data) {
+    sharedPreferencesHelper.getSettings('textNotification').then((data) {
       setState(() {
         _textNotification = data;
       });
@@ -64,7 +58,7 @@ class _SettingsGeneral extends State<SettingsGeneral> {
             _darkMode,
             (bool value) {
               setState(() {
-                _switchSetting('darkMode', value);
+                sharedPreferencesHelper.setSettings('darkMode', value);
                 _darkMode = value;
                 print("Dark mode: " + _darkMode.toString());
               });
@@ -75,7 +69,7 @@ class _SettingsGeneral extends State<SettingsGeneral> {
             _emailNotification,
             (bool value) {
               setState(() {
-                _switchSetting('emailNotification', value);
+                sharedPreferencesHelper.setSettings('emailNotification', value);
                 _emailNotification = value;
                 print("Email notification: " + _emailNotification.toString());
               });
@@ -86,15 +80,17 @@ class _SettingsGeneral extends State<SettingsGeneral> {
             _textNotification,
             (bool value) {
               setState(() {
-                _switchSetting('textNotification', value);
+                sharedPreferencesHelper.setSettings('textNotification', value);
                 _textNotification = value;
                 print("Text notification: " + _textNotification.toString());
               });
             },
           ),
           ListTile(
-            title: Row(
-                children: [Text('About   ', style: TextStyle(fontSize: 18.0)), Icon(CupertinoIcons.info_circle)]),
+            title: Row(children: [
+              Text('About   ', style: TextStyle(fontSize: 18.0)),
+              Icon(CupertinoIcons.info_circle)
+            ]),
             onTap: () {
               showDialog(
                   context: context,
@@ -123,5 +119,7 @@ class _SettingsGeneral extends State<SettingsGeneral> {
 // settings builder function
 SwitchListTile settingsList(String settingName, bool switchValue, setState) {
   return SwitchListTile(
-      title: Text(settingName, style: TextStyle(fontSize: 18.0)), value: switchValue, onChanged: setState);
+      title: Text(settingName, style: TextStyle(fontSize: 18.0)),
+      value: switchValue,
+      onChanged: setState);
 }

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:project_eureka_flutter/components/side_menu.dart';
+import 'package:project_eureka_flutter/screens/root_page.dart';
 import 'package:project_eureka_flutter/screens/settings/settings_account.dart';
 import 'package:project_eureka_flutter/screens/settings/settings_general.dart';
 import 'package:project_eureka_flutter/screens/settings/settings_payment.dart';
 import 'package:project_eureka_flutter/services/email_auth.dart';
-import 'package:project_eureka_flutter/screens/login_page.dart';
 
 class SettingsScreen extends StatelessWidget {
   final EmailAuth _emailAuth = new EmailAuth();
@@ -31,7 +31,7 @@ class SettingsScreen extends StatelessWidget {
     _emailAuth.signOut().then((_) => Navigator.pushAndRemoveUntil(
         context,
         MaterialPageRoute<Widget>(
-            builder: (BuildContext context) => LoginPage()),
+            builder: (BuildContext context) => RootPage()),
         (Route<void> route) => false));
   }
 

--- a/lib/screens/signup_page.dart
+++ b/lib/screens/signup_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
+import 'package:project_eureka_flutter/screens/root_page.dart';
 import 'package:project_eureka_flutter/services/email_auth.dart';
 import 'package:project_eureka_flutter/services/firebase_exception_handler.dart';
 
@@ -41,7 +42,7 @@ class _SignupPageState extends State<SignupPage> {
             context,
             MaterialPageRoute(
               builder: (context) {
-                return LoginPage();
+                return RootPage();
               },
             ),
           );
@@ -125,7 +126,7 @@ class _SignupPageState extends State<SignupPage> {
           context,
           MaterialPageRoute(
             builder: (context) {
-              return LoginPage();
+              return RootPage();
             },
           ),
         );

--- a/lib/services/shared_preferences_helper.dart
+++ b/lib/services/shared_preferences_helper.dart
@@ -1,0 +1,25 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class SharedPreferencesHelper {
+  static final _initScreen = 'initScreen';
+
+  Future<bool> setInitScreen(int initScreen) async {
+    SharedPreferences prefs = await SharedPreferences.getInstance();
+    return prefs.setInt(_initScreen, initScreen);
+  }
+
+  int getInitScreen(SharedPreferences prefs) {
+    return prefs.containsKey(_initScreen) ? prefs.getInt(_initScreen) : null;
+  }
+
+  Future<bool> getSettings(String setting) async {
+    SharedPreferences prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(setting) ??
+        false; // if setting doesn't exist yet, give false
+  }
+
+  Future<void> setSettings(String setting, bool value) async {
+    SharedPreferences prefs = await SharedPreferences.getInstance();
+    prefs.setBool(setting, value);
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,7 +36,7 @@ dependencies:
   date_time_picker: ^1.1.0
   material_segmented_control: ^2.1.0+1
   toggle_switch: ^0.1.8
-  introduction_screen: ^1.0.7
+  introduction_screen: ^1.0.9
   shared_preferences: ^0.5.12+4
 
 dev_dependencies:


### PR DESCRIPTION
**What I Did:**
- Created a Root Page to handle any checks for certain status.
- Implemented a Shared Preferences Handler to store all shared preferences app wide.
- Moved any checking functions into Root Page 

**How To Test:**
1. You will need to delete all data for this test!!! You can do this by deleting the app on the device or Android app settings.
2. After running the app, you should see the onboarding. After onboarding, you should see Login(). Don't login yet, instead close the app and reopen to see if the app remembers and goes directly to Login Page.
3. If app remembers, now login.
4. Then close app again and then open. The app should be signed in and you should see the Home Page.
5. Go into General Settings and change the Dark Mode to a different settings. Then go back a screen then open the General Settings again. The settings should be saved. 
6. Sign out. Then close the app and open. The app should be in the Login Page.   