### PR TITLE
PE-101 | Added Route to More Details for Answers

### DIFF
--- a/lib/components/profile_answers_list.dart
+++ b/lib/components/profile_answers_list.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:project_eureka_flutter/screens/more_details_page.dart';
 import 'package:timeago/timeago.dart' as timeago;
 
 class ProfileAnswersView extends StatefulWidget {
@@ -95,7 +96,14 @@ class _ProfileAnswersViewState extends State<ProfileAnswersView> {
         FlatButton(
           materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
           onPressed: () {
-            // Question page redirection here
+            Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (context) => MoreDetails(
+                  questionId: widget.answersList[index].questionId,
+                ),
+              ),
+            );
           },
           child: Text(
             "Question Details",


### PR DESCRIPTION
**What I Did:**
- Added a route to open a screen under the Answers tab under Profile Screen for Answer Details.

**How to Test:**
1. Go to the Profile Screen and under the Answers Tab, click "Answers Details" . You should be pushed to the More Details Screen.