### PR TITLE
 PE-97 | Deleted unused (add video) toggle switch for both Create New Question and Answer pages

### DIFF
--- a/lib/screens/new_form_screens/new_form.dart
+++ b/lib/screens/new_form_screens/new_form.dart
@@ -79,18 +79,6 @@ class _NewFormState extends State<NewForm> {
     );
   }
 
-  Column _videoForm() {
-    return Column(
-      children: <Widget>[
-        Center(
-          child: Container(
-            child: Text("Create the video form here..."),
-          ),
-        )
-      ],
-    );
-  }
-
   Widget _scrollingForm() {
     return _isUploading
         ? Center(
@@ -105,7 +93,7 @@ class _NewFormState extends State<NewForm> {
             child: Column(
               children: <Widget>[
                 EurekaToggleSwitch(
-                    labels: ['Text', 'Photo', 'Video'],
+                    labels: ['Text', 'Photo'],
                     initialLabelIndex: _formType,
                     setState: (index) {
                       setState(() {
@@ -124,10 +112,6 @@ class _NewFormState extends State<NewForm> {
                     picker: _imagePicker,
                   ),
                 ),
-                Visibility(
-                  visible: _formType == 2 ? true : false,
-                  child: _videoForm(),
-                )
               ],
             ),
           );


### PR DESCRIPTION
What I did:
-deleted unused toggle switch for Video upload

How to test:

- switch to branch 97
- git pull
- git fetch
- Step 1: on home page create new question -> select any category -> you should see only text or image options on top of the screen. Make sure create new question workflow is not broken
- Step 2: On home page click on any question that's not yours -> answer -> answer -> you should see only text or image options on top of the screen. Make sure answer question workflow is not broken.

