### PR TITLE
PE-104 | Improved navigation routes. Also: Cleaned code, Fixed bugs on Profile and More Details pages

### DIFF
--- a/lib/components/eureka_list_view.dart
+++ b/lib/components/eureka_list_view.dart
@@ -77,9 +77,16 @@ class _EurekaListViewState extends State<EurekaListView> {
             _eurekaListViewTextStyle(
               value:
                   // 'closed' is a boolean
-                  widget.questionList[index].closed ? "Closed" : "Active",
-              color:
-                  widget.questionList[index].closed ? Colors.grey : Colors.blue,
+                  !widget.questionList[index].visible
+                      ? "Archived"
+                      : widget.questionList[index].closed
+                          ? "Closed"
+                          : "Active",
+              color: !widget.questionList[index].visible
+                  ? Colors.grey
+                  : widget.questionList[index].closed
+                      ? Colors.grey
+                      : Colors.blue,
               fontWeight: FontWeight.bold,
             ),
           ],

--- a/lib/components/eureka_rounded_button.dart
+++ b/lib/components/eureka_rounded_button.dart
@@ -8,6 +8,7 @@ class EurekaRoundedButton extends StatefulWidget {
   final String buttonText;
   final Color buttonColor;
   final Color textColor;
+  final bool isTwoButtons;
 
   /// Users will need to pass in values for the onPressed interation and
   /// what the text for this button will be.
@@ -15,7 +16,8 @@ class EurekaRoundedButton extends StatefulWidget {
       {@required this.onPressed,
       @required this.buttonText,
       this.buttonColor,
-      this.textColor});
+      this.textColor,
+      this.isTwoButtons});
 
   @override
   _EurekaRoundedButtonState createState() => _EurekaRoundedButtonState();
@@ -27,7 +29,7 @@ class _EurekaRoundedButtonState extends State<EurekaRoundedButton> {
   @override
   Widget build(BuildContext context) {
     return Container(
-      padding: EdgeInsets.all(20.0),
+      padding: widget.isTwoButtons == null ? EdgeInsets.all(20.0) : EdgeInsets.all(9.0),
       child: FlatButton(
         onPressed: widget.onPressed,
         disabledColor: Colors.grey[400],

--- a/lib/components/more_details_view.dart
+++ b/lib/components/more_details_view.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:project_eureka_flutter/components/eureka_image_viewer.dart';
 import 'package:project_eureka_flutter/models/more_details_model.dart';
 import 'package:project_eureka_flutter/models/user_answer_model.dart';
-import 'package:project_eureka_flutter/screens/choose_best_answer.dart';
 import 'package:project_eureka_flutter/screens/home_screen.dart';
 import 'package:project_eureka_flutter/screens/new_form_screens/new_form.dart';
 import 'package:project_eureka_flutter/services/close_question_service.dart';
@@ -303,18 +302,6 @@ class _MoreDetailsViewState extends State<MoreDetailsView> {
     );
   }
 
-  void _closeQuestion() {
-    Navigator.push(
-      context,
-      MaterialPageRoute(
-        builder: (context) => ChooseBestAnswer(
-          questionId: widget.moreDetailModel.question.id,
-          answers: widget.moreDetailModel.userAnswer,
-        ),
-      ),
-    );
-  }
-
   void _answerQuestion() {
     Navigator.push(
       context,
@@ -336,10 +323,6 @@ class _MoreDetailsViewState extends State<MoreDetailsView> {
               _answerQuestion();
             }
             break;
-            case 'Close': {
-              _closeQuestion();
-            }
-            break;
             case 'Archive': {
               _archiveQuestion();
             }
@@ -352,11 +335,6 @@ class _MoreDetailsViewState extends State<MoreDetailsView> {
         const PopupMenuItem<String>(
           value: 'Answer',
           child: Text('Answer'),
-        ),
-        if((widget.moreDetailModel.question.closed != true) & (widget.moreDetailModel.userAnswer.length != 0))
-        const PopupMenuItem<String>(
-          value: 'Close',
-          child: Text('Close'),
         ),
         if(widget.moreDetailModel.question.visible != false)
         const PopupMenuItem<String>(

--- a/lib/components/more_details_view.dart
+++ b/lib/components/more_details_view.dart
@@ -276,6 +276,7 @@ class _MoreDetailsViewState extends State<MoreDetailsView> {
     return (!widget.isCurrUser ? Container() : messageIcon());
   }
 
+  /* DROP DOWN MENU - BEGIN */
   Future<void> _archiveQuestion() async {
     await CloseQuestionService()
         .archiveQuestion(widget.moreDetailModel.question.id);
@@ -314,21 +315,25 @@ class _MoreDetailsViewState extends State<MoreDetailsView> {
     );
   }
 
+  void _answerQuestion() {
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (context) => NewForm(
+          isAnswer: true,
+          questionId: widget.moreDetailModel.question.id,
+        ),
+      ), // standard form
+    );
+  }
+
   PopupMenuButton _questionMenu(bool isArchived, bool isClosed) {
     return PopupMenuButton<String>(
       onSelected: (String result) {
         setState(() {
           switch(result) {
             case 'Answer': {
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (context) => NewForm(
-                    isAnswer: true,
-                    questionId: widget.moreDetailModel.question.id,
-                  ),
-                ), // standard form
-              );
+              _answerQuestion();
             }
             break;
             case 'Close': {
@@ -361,6 +366,8 @@ class _MoreDetailsViewState extends State<MoreDetailsView> {
       ],
     );
   }
+
+  /* DROP DOWN MENU - END */
 
   @override
   Widget build(BuildContext context) {

--- a/lib/components/profile_answers_list.dart
+++ b/lib/components/profile_answers_list.dart
@@ -61,12 +61,15 @@ class _ProfileAnswersViewState extends State<ProfileAnswersView> {
                 ),
               ],
             ),
-            _eurekaListViewTextStyle(
-              value: index == 1
+            Text(
+              (widget.answersList[index].bestAnswer == true)
                   ? "Best Answer"
-                  : "", // for testing purposes it only shows one best answer
-              color: Colors.blue,
-              fontWeight: FontWeight.bold,
+                  : "",
+              style: TextStyle(
+                  fontSize: 15.0,
+                  fontStyle: FontStyle.italic,
+                  fontWeight: FontWeight.bold,
+                  color: Colors.green),
             ),
           ],
         ),

--- a/lib/screens/choose_best_answer.dart
+++ b/lib/screens/choose_best_answer.dart
@@ -4,7 +4,9 @@ import 'package:project_eureka_flutter/components/eureka_rounded_button.dart';
 import 'package:project_eureka_flutter/components/more_details_view.dart';
 import 'package:project_eureka_flutter/models/user_answer_model.dart';
 import 'package:project_eureka_flutter/screens/rating_screen.dart';
+import 'package:project_eureka_flutter/services/close_question_service.dart';
 import 'package:project_eureka_flutter/services/email_auth.dart';
+import 'package:project_eureka_flutter/screens/more_details_page.dart';
 
 class ChooseBestAnswer extends StatefulWidget {
   final String questionId;
@@ -26,6 +28,15 @@ class _ChooseBestAnswerState extends State<ChooseBestAnswer> {
     setState(() {
       bestAnswerIndex = i;
     });
+  }
+
+  Future<void> _closeQuestion(String answerId) async {
+    final response =
+        await CloseQuestionService().closeQuestion(widget.questionId, answerId);
+    print("Status " +
+        response.statusCode.toString() +
+        ". Question closed successfully - " +
+        widget.questionId.toString());
   }
 
   @override
@@ -100,7 +111,19 @@ class _ChooseBestAnswerState extends State<ChooseBestAnswer> {
               ? null
               : () => widget.answers[bestAnswerIndex].user.id ==
                       EmailAuth().getCurrentUser().uid
-                  ? Navigator.of(context).pushNamed('/home')
+                  ? {
+                       _closeQuestion(widget.answers[bestAnswerIndex].answer.id),
+                      Navigator.pushNamedAndRemoveUntil(
+                          context, '/home', (Route<void> route) => false),
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (context) => MoreDetails(
+                            questionId: widget.questionId,
+                          ),
+                        ),
+                      ),
+                    }
                   : Navigator.push(
                       context,
                       MaterialPageRoute(

--- a/lib/screens/more_details_page.dart
+++ b/lib/screens/more_details_page.dart
@@ -13,12 +13,9 @@ import 'package:project_eureka_flutter/screens/choose_best_answer.dart';
 import 'package:project_eureka_flutter/screens/new_form_screens/new_form.dart';
 import 'package:project_eureka_flutter/services/email_auth.dart';
 import 'package:project_eureka_flutter/services/more_detail_service.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:project_eureka_flutter/screens/chat_screens/chat_screen.dart';
-import 'package:project_eureka_flutter/services/users_service.dart';
 
 final _firestore = FirebaseFirestore.instance;
-User loggedInUser = EmailAuth().getCurrentUser();
 
 class MoreDetails extends StatefulWidget {
   final String questionId;
@@ -37,32 +34,24 @@ class _MoreDetailsState extends State<MoreDetails> {
     user: UserModel(),
     userAnswer: [UserAnswerModel()],
   );
-  UserModel user;
-  final String currUserId = EmailAuth().getCurrentUser().uid;
-  //UserModel currUser;
+  String currUserId;
+  bool loading;
 
   @override
   void initState() {
+    loading = true;
     initGetQuestionDetails();
-    initGetUserDetails();
+    currUserId = EmailAuth().getCurrentUser().uid;
     super.initState();
   }
 
-  Future<void> initGetQuestionDetails() async {
-    MoreDetailModel payload =
-        await MoreDetailService().getMoreDetail(widget.questionId);
-
-    setState(() {
-      _moreDetailModel = payload;
-    });
-  }
-
-  Future<void> initGetUserDetails() async {
-    UserModel payload = await UserService().getUserById(loggedInUser.uid);
-
-    setState(() {
-      user = payload;
-    });
+  void initGetQuestionDetails() async {
+    await MoreDetailService().getMoreDetail(widget.questionId).then((payload) {
+          setState(() {
+            _moreDetailModel = payload;
+            loading = false;
+          });
+        });
   }
 
   EurekaRoundedButton _messageModalButton() {
@@ -82,6 +71,7 @@ class _MoreDetailsState extends State<MoreDetails> {
         );
       },
       buttonText: 'Message ${_moreDetailModel.user.firstName}',
+      isTwoButtons: true,
     );
   }
 
@@ -96,7 +86,8 @@ class _MoreDetailsState extends State<MoreDetails> {
           ),
         ), // standard form
       ),
-      buttonText: 'Answer',
+      buttonText: 'Answer ',
+      isTwoButtons: true,
     );
   }
 
@@ -108,8 +99,6 @@ class _MoreDetailsState extends State<MoreDetails> {
 
     _firestore.collection('messages').doc(groupChatId).set({
       'chatIDUser': currUserId,
-      'chatSender': user.firstName,
-      'recipient': _moreDetailModel.user.firstName,
       'recipientId': _moreDetailModel.user.id,
       'questionTitle': _moreDetailModel.question.title,
       'questionId': _moreDetailModel.question.id,
@@ -216,6 +205,7 @@ class _MoreDetailsState extends State<MoreDetails> {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
+                if(!loading)
                 MoreDetailsView(
                   moreDetailModel: _moreDetailModel,
                   isAnswer: false,
@@ -239,6 +229,7 @@ class _MoreDetailsState extends State<MoreDetails> {
                   ),
                 ),
                 _noAnswersResponse(),
+                if(!loading)
                 _answersListBuilder(),
               ],
             ),

--- a/lib/screens/more_details_page.dart
+++ b/lib/screens/more_details_page.dart
@@ -13,6 +13,7 @@ import 'package:project_eureka_flutter/screens/new_form_screens/new_form.dart';
 import 'package:project_eureka_flutter/services/email_auth.dart';
 import 'package:project_eureka_flutter/services/more_detail_service.dart';
 import 'package:project_eureka_flutter/screens/chat_screens/chat_screen.dart';
+import 'package:project_eureka_flutter/screens/choose_best_answer.dart';
 
 final _firestore = FirebaseFirestore.instance;
 
@@ -133,6 +134,23 @@ class _MoreDetailsState extends State<MoreDetails> {
     );
   }
 
+  EurekaRoundedButton _closeQuestionButton() {
+    return EurekaRoundedButton(
+      onPressed: () {
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (context) => ChooseBestAnswer(
+              questionId: widget.questionId,
+              answers: _moreDetailModel.userAnswer,
+            ),
+          ),
+        );
+      },
+      buttonText: "Question Solved?",
+    );
+  }
+
   Visibility _noAnswersResponse() {
     return Visibility(
       visible: _moreDetailModel.userAnswer.length == 0,
@@ -249,7 +267,8 @@ class _MoreDetailsState extends State<MoreDetails> {
                     : (_moreDetailModel.user.id !=
                             currUserId // if currUser is question poster
                         ? _answerQuestionButton() // false = answer question
-                        : null)),
+                        : ((_moreDetailModel.question.closed != true) & (_moreDetailModel.userAnswer.length != 0))
+                          ? _closeQuestionButton() : null )),
       ),
     );
   }

--- a/lib/screens/more_details_page.dart
+++ b/lib/screens/more_details_page.dart
@@ -120,18 +120,26 @@ class _MoreDetailsState extends State<MoreDetails> {
   EurekaRoundedButton _answerQuestionButton() {
     return EurekaRoundedButton(
       onPressed: () {
-        showModalBottomSheet(
-          context: context,
-          builder: (context) => Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              _moreDetailModel.user.id == currUserId
-                  ? Container()
-                  : _messageModalButton(),
-              _answerFormModalButton(),
-            ],
-          ),
-        );
+        _moreDetailModel.user.id == currUserId
+            ? Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (context) => NewForm(
+                    isAnswer: true,
+                    questionId: widget.questionId,
+                  ),
+                ), // standard form
+              )
+            : showModalBottomSheet(
+                context: context,
+                builder: (context) => Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    _messageModalButton(),
+                    _answerFormModalButton(),
+                  ],
+                ),
+              );
       },
       buttonText: "Answer",
     );

--- a/lib/screens/more_details_page.dart
+++ b/lib/screens/more_details_page.dart
@@ -9,7 +9,6 @@ import 'package:project_eureka_flutter/models/more_details_model.dart';
 import 'package:project_eureka_flutter/models/question_model.dart';
 import 'package:project_eureka_flutter/models/user_answer_model.dart';
 import 'package:project_eureka_flutter/models/user_model.dart';
-import 'package:project_eureka_flutter/screens/choose_best_answer.dart';
 import 'package:project_eureka_flutter/screens/new_form_screens/new_form.dart';
 import 'package:project_eureka_flutter/services/email_auth.dart';
 import 'package:project_eureka_flutter/services/more_detail_service.dart';
@@ -149,23 +148,6 @@ class _MoreDetailsState extends State<MoreDetails> {
     );
   }
 
-  EurekaRoundedButton _questionIsSolvedButton() {
-    return EurekaRoundedButton(
-      onPressed: () {
-        Navigator.push(
-          context,
-          MaterialPageRoute(
-            builder: (context) => ChooseBestAnswer(
-              questionId: _moreDetailModel.question.id,
-              answers: _moreDetailModel.userAnswer,
-            ),
-          ),
-        );
-      },
-      buttonText: 'Question Solved?',
-    );
-  }
-
   Column _answersListBuilder() {
     return Column(
       children: [
@@ -267,9 +249,7 @@ class _MoreDetailsState extends State<MoreDetails> {
                     : (_moreDetailModel.user.id !=
                             currUserId // if currUser is question poster
                         ? _answerQuestionButton() // false = answer question
-                        : _moreDetailModel.userAnswer.length == 0
-                            ? _answerQuestionButton()
-                            : _questionIsSolvedButton())),
+                        : null)),
       ),
     );
   }

--- a/lib/screens/new_form_screens/new_form_confirmation.dart
+++ b/lib/screens/new_form_screens/new_form_confirmation.dart
@@ -5,6 +5,7 @@ import 'package:project_eureka_flutter/components/eureka_rounded_button.dart';
 import 'package:project_eureka_flutter/models/answer_model.dart';
 import 'package:project_eureka_flutter/models/question_model.dart';
 import 'package:project_eureka_flutter/screens/home_screen.dart';
+import 'package:project_eureka_flutter/screens/more_details_page.dart';
 
 class NewFormConfirmation extends StatefulWidget {
   final bool isAnswer; // true: this for is for Answers
@@ -141,14 +142,19 @@ class _NewFormConfirmationState extends State<NewFormConfirmation> {
       ),
       body: _formConfirmationBody(),
       bottomNavigationBar: EurekaRoundedButton(
-        buttonText: "Return to Home Page",
-        onPressed: () => Navigator.push(
-          context,
-          MaterialPageRoute(
-            builder: (context) => Home(),
-          ),
-        ),
-      ),
+          buttonText: "Go to Question",
+          onPressed: () => {
+                Navigator.pushNamedAndRemoveUntil(
+                    context, '/home', (Route<void> route) => false),
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => MoreDetails(
+                      questionId: widget.questionModel.id,
+                    ),
+                  ),
+                ),
+              }),
     );
   }
 }

--- a/lib/screens/new_form_screens/new_form_confirmation.dart
+++ b/lib/screens/new_form_screens/new_form_confirmation.dart
@@ -4,7 +4,6 @@ import 'package:project_eureka_flutter/components/eureka_image_viewer.dart';
 import 'package:project_eureka_flutter/components/eureka_rounded_button.dart';
 import 'package:project_eureka_flutter/models/answer_model.dart';
 import 'package:project_eureka_flutter/models/question_model.dart';
-import 'package:project_eureka_flutter/screens/home_screen.dart';
 import 'package:project_eureka_flutter/screens/more_details_page.dart';
 
 class NewFormConfirmation extends StatefulWidget {
@@ -150,7 +149,8 @@ class _NewFormConfirmationState extends State<NewFormConfirmation> {
                   context,
                   MaterialPageRoute(
                     builder: (context) => MoreDetails(
-                      questionId: widget.questionModel.id,
+                      questionId:
+                      widget.isAnswer ? widget.answerModel.questionId : widget.questionModel.id,
                     ),
                   ),
                 ),

--- a/lib/screens/profile_onboarding_screen.dart
+++ b/lib/screens/profile_onboarding_screen.dart
@@ -6,8 +6,8 @@ import 'package:image_picker/image_picker.dart';
 import 'package:project_eureka_flutter/components/eureka_appbar.dart';
 import 'package:project_eureka_flutter/components/eureka_profile_button.dart';
 import 'package:project_eureka_flutter/components/eureka_text_form_field.dart';
-import 'package:project_eureka_flutter/components/eureka_toggle_switch.dart';
 import 'package:project_eureka_flutter/models/user_model.dart';
+import 'package:project_eureka_flutter/screens/profile_screen.dart';
 import 'package:project_eureka_flutter/services/email_auth.dart';
 import 'package:project_eureka_flutter/services/profile_onboarding_service.dart';
 import 'package:firebase_storage/firebase_storage.dart';
@@ -138,6 +138,7 @@ class _ProfileOnboardingState extends State<ProfileOnboarding> {
                       color: Colors.white,
                     )
                   : CircleAvatar(
+                      backgroundColor: Colors.transparent,
                       backgroundImage: FileImage(File(mediaPath)),
                       radius: 50.0,
                     ),
@@ -188,7 +189,7 @@ class _ProfileOnboardingState extends State<ProfileOnboarding> {
       email: _firebaseUser.email,
       city: '',
       category: [], //we don't have form field for this
-      pictureUrl: mediaUrl.length == 0 ? '' : mediaUrl[0],
+      pictureUrl: mediaUrl.length == 0 ? widget.user.pictureUrl : mediaUrl[0],
       role: _role,
       ratings: [],
       averageRating: 0.0,
@@ -201,7 +202,12 @@ class _ProfileOnboardingState extends State<ProfileOnboarding> {
         // This currently doesn't work until we can get the current user_id
         await _profileOnboardingService.updateUser(_firebaseUser.uid, user);
 
-        Navigator.pop(context);
+        Navigator.pushAndRemoveUntil(
+            context,
+            MaterialPageRoute(
+              builder: (context) => Profile(),
+            ),
+            (Route<void> route) => false);
       } else {
         // Using HTTP POST to add new user
         await _profileOnboardingService.addUser(user);

--- a/lib/screens/rating_screen.dart
+++ b/lib/screens/rating_screen.dart
@@ -3,11 +3,10 @@ import 'package:flutter_rating_bar/flutter_rating_bar.dart';
 import 'package:project_eureka_flutter/components/eureka_rounded_button.dart';
 import 'package:project_eureka_flutter/models/rating_model.dart';
 import 'package:project_eureka_flutter/models/user_model.dart';
+import 'package:project_eureka_flutter/screens/profile_screen.dart';
 import 'package:project_eureka_flutter/services/close_question_service.dart';
-import 'package:project_eureka_flutter/services/email_auth.dart';
 import 'package:project_eureka_flutter/services/rating_service.dart';
-
-import 'home_screen.dart';
+import 'package:project_eureka_flutter/screens/more_details_page.dart';
 
 class Rating extends StatefulWidget {
   final UserModel userInfo;
@@ -55,7 +54,20 @@ class _RatingState extends State<Rating> {
                     child: FlatButton(
                         onPressed: () async => {
                               await _closeQuestion(),
-                              Navigator.of(context).pushNamed('/home')
+                              Navigator.pushAndRemoveUntil(
+                                  context,
+                                  MaterialPageRoute(
+                                    builder: (context) => Profile(),
+                                  ),
+                                  (Route<void> route) => false),
+                              Navigator.push(
+                                context,
+                                MaterialPageRoute(
+                                  builder: (context) => MoreDetails(
+                                    questionId: widget.questionId,
+                                  ),
+                                ),
+                              )
                             },
                         child: Text('Skip', style: TextStyle(fontSize: 18))),
                   ),
@@ -72,7 +84,10 @@ class _RatingState extends State<Rating> {
                               widget.userInfo.lastName,
                           24.0),
                       _ratingBar(_ratingBarMode),
-                      ratingNotChosenError ? Text("Please choose rating", style: TextStyle(color: Colors.red)) : Text("")
+                      ratingNotChosenError
+                          ? Text("Please choose rating",
+                              style: TextStyle(color: Colors.red))
+                          : Text("")
                     ],
                   ),
                   SizedBox(
@@ -112,7 +127,22 @@ class _RatingState extends State<Rating> {
     } catch (e) {
       print(e);
     }
-    Navigator.of(context).pushNamed('/home');
+
+    Navigator.pushAndRemoveUntil(
+        context,
+        MaterialPageRoute(
+          builder: (context) => Profile(),
+        ),
+        (Route<void> route) => false);
+
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (context) => MoreDetails(
+          questionId: widget.questionId,
+        ),
+      ),
+    );
   }
 
   void checkRating() {

--- a/lib/screens/rating_screen.dart
+++ b/lib/screens/rating_screen.dart
@@ -3,7 +3,6 @@ import 'package:flutter_rating_bar/flutter_rating_bar.dart';
 import 'package:project_eureka_flutter/components/eureka_rounded_button.dart';
 import 'package:project_eureka_flutter/models/rating_model.dart';
 import 'package:project_eureka_flutter/models/user_model.dart';
-import 'package:project_eureka_flutter/screens/home_screen.dart';
 import 'package:project_eureka_flutter/services/close_question_service.dart';
 import 'package:project_eureka_flutter/services/rating_service.dart';
 import 'package:project_eureka_flutter/screens/more_details_page.dart';

--- a/lib/screens/rating_screen.dart
+++ b/lib/screens/rating_screen.dart
@@ -3,7 +3,7 @@ import 'package:flutter_rating_bar/flutter_rating_bar.dart';
 import 'package:project_eureka_flutter/components/eureka_rounded_button.dart';
 import 'package:project_eureka_flutter/models/rating_model.dart';
 import 'package:project_eureka_flutter/models/user_model.dart';
-import 'package:project_eureka_flutter/screens/profile_screen.dart';
+import 'package:project_eureka_flutter/screens/home_screen.dart';
 import 'package:project_eureka_flutter/services/close_question_service.dart';
 import 'package:project_eureka_flutter/services/rating_service.dart';
 import 'package:project_eureka_flutter/screens/more_details_page.dart';
@@ -57,7 +57,7 @@ class _RatingState extends State<Rating> {
                               Navigator.pushAndRemoveUntil(
                                   context,
                                   MaterialPageRoute(
-                                    builder: (context) => Profile(),
+                                    builder: (context) => Home(),
                                   ),
                                   (Route<void> route) => false),
                               Navigator.push(
@@ -131,7 +131,7 @@ class _RatingState extends State<Rating> {
     Navigator.pushAndRemoveUntil(
         context,
         MaterialPageRoute(
-          builder: (context) => Profile(),
+          builder: (context) => Home(),
         ),
         (Route<void> route) => false);
 

--- a/lib/screens/rating_screen.dart
+++ b/lib/screens/rating_screen.dart
@@ -54,12 +54,8 @@ class _RatingState extends State<Rating> {
                     child: FlatButton(
                         onPressed: () async => {
                               await _closeQuestion(),
-                              Navigator.pushAndRemoveUntil(
-                                  context,
-                                  MaterialPageRoute(
-                                    builder: (context) => Home(),
-                                  ),
-                                  (Route<void> route) => false),
+                              Navigator.pushNamedAndRemoveUntil(context,
+                                  '/home', (Route<void> route) => false),
                               Navigator.push(
                                 context,
                                 MaterialPageRoute(
@@ -127,14 +123,8 @@ class _RatingState extends State<Rating> {
     } catch (e) {
       print(e);
     }
-
-    Navigator.pushAndRemoveUntil(
-        context,
-        MaterialPageRoute(
-          builder: (context) => Home(),
-        ),
-        (Route<void> route) => false);
-
+    Navigator.pushNamedAndRemoveUntil(
+        context, '/home', (Route<void> route) => false);
     Navigator.push(
       context,
       MaterialPageRoute(


### PR DESCRIPTION
What I Did:
- Updated ratings_sceen.dart file
- Now after closing the question (rating the user or skipping rating), the question owner will be navigated to the updated question details page. Same after answering
- Fixed errors on more details page
- Added drop-down menu on More Details page for question owner. It includes Close, Answer, and Archive question selections.
- Added changes to edit profile screen: it won't remove the old images if one wasn't selected (bug fixed). Navigation was also changed to "pushAndRemoveUntil" so that we can see the new changes.
- Fixed bestAnswer in the list of answers on Profile Screen

How to Test:
- User must be navigated to question details after closing the question or answering any question, and the back button must bring to a home page
- There must be no errors on any of the pages
- User must navigate back after editing the profile and see the new changes appearing in the profile. If the image wasn't added, it won't remove it like previously.
- Archived questions in the profile must have "archived" status
- Best answers must have the best answer status
- Dropdown menu must be visible only to the question owner, otherwise, it will show a chat icon
- Dropdown selection must vary based on different conditions: Close selection will be visible if question is waiting for answers; Answer selection will be visible if the question is not closed yet. The archive selection will be visible always. If the question is archived, the dropdown menu won't show up at all.

**All edits are open to suggestions**