### PR TITLE
PE-103 | Add New Message Visibility

### DIFF
--- a/lib/screens/chat_screens/chat_screen.dart
+++ b/lib/screens/chat_screens/chat_screen.dart
@@ -174,10 +174,11 @@ class _ChatScreenState extends State<ChatScreen>
         'idFrom': userId,
         'idTo': widget.fromId,
       });
-      _firestore
-          .collection('messages')
-          .doc(groupChatId)
-          .update({'timestamp': DateTime.now()});
+      _firestore.collection('messages').doc(groupChatId).update({
+        'timestamp': DateTime.now(),
+        'unseen': true,
+        'lastMessageSender': loggedInUser.uid
+      });
     }
     await Navigator.push(
       context,
@@ -243,7 +244,11 @@ class _ChatScreenState extends State<ChatScreen>
                       _firestore
                           .collection('messages')
                           .doc(groupChatId)
-                          .update({'timestamp': DateTime.now()});
+                          .update({
+                        'timestamp': DateTime.now(),
+                        'unseen': true,
+                        'lastMessageSender': loggedInUser.uid
+                      });
                     }
                   }),
             ],

--- a/lib/screens/chat_screens/chat_screen.dart
+++ b/lib/screens/chat_screens/chat_screen.dart
@@ -84,7 +84,7 @@ class _ChatScreenState extends State<ChatScreen>
         .collection('messages')
         .doc(groupChatId)
         .update({
-      userId: true,});
+      userId: false,});
     super.dispose();
   }
 
@@ -377,13 +377,12 @@ class _ChatScreenState extends State<ChatScreen>
                         'idFrom': userId,
                         'idTo': widget.fromId,
                       });
-
                       _firestore
                           .collection('messages')
                           .doc(groupChatId)
                           .get()
                           .then((snapshot) {
-                        if(snapshot.data()[widget.fromId] == false)
+                        if(snapshot.data()[widget.fromId] == false) {
                           _firestore
                               .collection('messages')
                               .doc(groupChatId)
@@ -392,6 +391,17 @@ class _ChatScreenState extends State<ChatScreen>
                             'unseen': true,
                             'lastMessageSender': loggedInUser.uid
                           });
+                        }
+                        else {
+                          _firestore
+                              .collection('messages')
+                              .doc(groupChatId)
+                              .update({
+                            'timestamp': DateTime.now(),
+                            'unseen': false,
+                            'lastMessageSender': loggedInUser.uid
+                          });
+                        }
                       });
                     },
                     child: Text(

--- a/lib/screens/chat_screens/chat_screen.dart
+++ b/lib/screens/chat_screens/chat_screen.dart
@@ -88,11 +88,9 @@ class _ChatScreenState extends State<ChatScreen>
   @override
   void dispose() {
     _controller.dispose();
-    _firestore
-        .collection('messages')
-        .doc(groupChatId)
-        .update({
-      userId: false,});
+    _firestore.collection('messages').doc(groupChatId).update({
+      userId: false,
+    });
     super.dispose();
   }
 
@@ -404,7 +402,7 @@ class _ChatScreenState extends State<ChatScreen>
                           .doc(groupChatId)
                           .get()
                           .then((snapshot) {
-                        if(snapshot.data()[widget.fromId] == false) {
+                        if (snapshot.data()[widget.fromId] == false) {
                           _firestore
                               .collection('messages')
                               .doc(groupChatId)
@@ -413,8 +411,7 @@ class _ChatScreenState extends State<ChatScreen>
                             'unseen': true,
                             'lastMessageSender': loggedInUser.uid
                           });
-                        }
-                        else {
+                        } else {
                           _firestore
                               .collection('messages')
                               .doc(groupChatId)

--- a/lib/screens/chat_screens/chat_screen.dart
+++ b/lib/screens/chat_screens/chat_screen.dart
@@ -19,7 +19,15 @@ class ChatScreen extends StatefulWidget {
   final String fromId;
   final String recipient;
   final String questionId;
-  const ChatScreen({Key key, this.fromId, this.recipient, this.questionId})
+  final String lastMessageSender;
+  final bool enteredChat;
+  const ChatScreen(
+      {Key key,
+      this.fromId,
+      this.recipient,
+      this.questionId,
+      this.lastMessageSender,
+      this.enteredChat})
       : super(key: key);
 
   @override
@@ -55,7 +63,7 @@ class _ChatScreenState extends State<ChatScreen>
     userId = loggedInUser.uid;
     groupChatId = userId + "-" + widget.fromId + "-" + widget.questionId;
     setGroupId();
-
+    setEnteredChat();
     // initialize channel names for two cases:
     // 1: channelNameCall - user calls and joins the channel; (initialized to empty string)
     // 2: channelNameAnswer - user clicks answer and joins the created channel
@@ -80,6 +88,8 @@ class _ChatScreenState extends State<ChatScreen>
   @override
   void dispose() {
     _controller.dispose();
+    setLeftChat();
+    print('run');
     super.dispose();
   }
 
@@ -103,6 +113,18 @@ class _ChatScreenState extends State<ChatScreen>
         },
       );
     }
+  }
+
+  void setEnteredChat() async {
+    _firestore.collection('messages').doc(groupChatId).update({
+      'enteredChat': true,
+    });
+  }
+
+  void setLeftChat() async {
+    _firestore.collection('messages').doc(groupChatId).update({
+      'enteredChat': false,
+    });
   }
 
   void setGroupId() async {
@@ -315,8 +337,10 @@ class _ChatScreenState extends State<ChatScreen>
                       // if sender String contains caller's ID, show Answer button. Caller won't see answer button
                       showAnswerButton: messageSender.contains(widget.fromId),
                       timestamp: messageTimestamp.toDate());
+
                   messageBubbles.add(messageBubble);
                 }
+
                 return Expanded(
                   child: ListView(
                     reverse: true,

--- a/lib/screens/chat_screens/chat_screen.dart
+++ b/lib/screens/chat_screens/chat_screen.dart
@@ -80,6 +80,11 @@ class _ChatScreenState extends State<ChatScreen>
   @override
   void dispose() {
     _controller.dispose();
+    _firestore
+        .collection('messages')
+        .doc(groupChatId)
+        .update({
+      userId: true,});
     super.dispose();
   }
 
@@ -358,7 +363,7 @@ class _ChatScreenState extends State<ChatScreen>
                     shape: RoundedRectangleBorder(
                         borderRadius: BorderRadius.circular(18.0)),
                     color: Colors.cyan,
-                    onPressed: () {
+                    onPressed: () async {
                       messageTextController.clear();
                       var currentTimeAndDate = DateTime.now();
                       _firestore
@@ -372,13 +377,21 @@ class _ChatScreenState extends State<ChatScreen>
                         'idFrom': userId,
                         'idTo': widget.fromId,
                       });
+
                       _firestore
                           .collection('messages')
                           .doc(groupChatId)
-                          .update({
-                        'timestamp': DateTime.now(),
-                        'unseen': true,
-                        'lastMessageSender': loggedInUser.uid
+                          .get()
+                          .then((snapshot) {
+                        if(snapshot.data()[widget.fromId] == false)
+                          _firestore
+                              .collection('messages')
+                              .doc(groupChatId)
+                              .update({
+                            'timestamp': DateTime.now(),
+                            'unseen': true,
+                            'lastMessageSender': loggedInUser.uid
+                          });
                       });
                     },
                     child: Text(

--- a/lib/screens/chat_screens/chat_screen.dart
+++ b/lib/screens/chat_screens/chat_screen.dart
@@ -370,7 +370,11 @@ class _ChatScreenState extends State<ChatScreen>
                       _firestore
                           .collection('messages')
                           .doc(groupChatId)
-                          .update({'timestamp': DateTime.now()});
+                          .update({
+                        'timestamp': DateTime.now(),
+                        'unseen': true,
+                        'lastMessageSender': loggedInUser.uid
+                      });
                     },
                     child: Text(
                       'Send',

--- a/lib/screens/chat_screens/chat_screen.dart
+++ b/lib/screens/chat_screens/chat_screen.dart
@@ -20,15 +20,14 @@ class ChatScreen extends StatefulWidget {
   final String recipient;
   final String questionId;
   final String lastMessageSender;
-  final bool enteredChat;
-  const ChatScreen(
-      {Key key,
-      this.fromId,
-      this.recipient,
-      this.questionId,
-      this.lastMessageSender,
-      this.enteredChat})
-      : super(key: key);
+
+  const ChatScreen({
+    Key key,
+    this.fromId,
+    this.recipient,
+    this.questionId,
+    this.lastMessageSender,
+  }) : super(key: key);
 
   @override
   _ChatScreenState createState() => new _ChatScreenState();
@@ -63,7 +62,7 @@ class _ChatScreenState extends State<ChatScreen>
     userId = loggedInUser.uid;
     groupChatId = userId + "-" + widget.fromId + "-" + widget.questionId;
     setGroupId();
-    setEnteredChat();
+
     // initialize channel names for two cases:
     // 1: channelNameCall - user calls and joins the channel; (initialized to empty string)
     // 2: channelNameAnswer - user clicks answer and joins the created channel
@@ -114,18 +113,6 @@ class _ChatScreenState extends State<ChatScreen>
         },
       );
     }
-  }
-
-  void setEnteredChat() async {
-    _firestore.collection('messages').doc(groupChatId).update({
-      'enteredChat': true,
-    });
-  }
-
-  void setLeftChat() async {
-    _firestore.collection('messages').doc(groupChatId).update({
-      'enteredChat': false,
-    });
   }
 
   void setGroupId() async {

--- a/lib/screens/chat_screens/user_chats.dart
+++ b/lib/screens/chat_screens/user_chats.dart
@@ -67,6 +67,8 @@ class ConversationsStream extends StatelessWidget {
           final unseen = userChat.data()['unseen'];
           final groupChatID = userChat.data()['groupChatId'];
           final lastMessageSender = userChat.data()['lastMessageSender'];
+          final meInTheRoom = userChat.data()[loggedInUser.uid];
+          final recipientInTheRoom = userChat.data()[recipientID];
           //if the user has not seen this message, then this will be true
           final conversationBubble = ConversationBubble(
             questionTitle: questionTitle,
@@ -96,6 +98,7 @@ class ConversationsStream extends StatelessWidget {
 
 Future<UserModel> initGetUserDetails(recipientId) async {
   UserModel payload = await UserService().getUserById(recipientId);
+  print(payload);
   return payload;
 }
 
@@ -115,6 +118,7 @@ class ConversationBubble extends StatelessWidget {
   final String groupId;
   final String lastMessageSender;
 
+
   @override
   Widget build(BuildContext context) {
     return FutureBuilder<UserModel>(
@@ -133,11 +137,16 @@ class ConversationBubble extends StatelessWidget {
                   onPressed: () {
                     print(recipientId);
                     print(loggedInUser.uid);
+                    if(unseen && lastMessageSender != loggedInUser.uid) {
+                      _firestore
+                          .collection('messages')
+                          .doc(groupId)
+                          .update({'unseen': false});
+                    }
                     _firestore
                         .collection('messages')
                         .doc(groupId)
-                        .update({'unseen': false});
-
+                        .update({loggedInUser.uid: true});
                     Navigator.push(
                         context,
                         MaterialPageRoute(

--- a/lib/screens/chat_screens/user_chats.dart
+++ b/lib/screens/chat_screens/user_chats.dart
@@ -76,6 +76,7 @@ class ConversationsStream extends StatelessWidget {
             questionId: questionID,
             unseen: unseen,
             groupId: groupChatID,
+            lastMessageSender: lastMessageSender,
           );
           if (conversationUserID == loggedInUser.uid ||
               recipientID == loggedInUser.uid) {
@@ -149,6 +150,16 @@ class ConversationBubble extends StatelessWidget {
                   },
                   child: Row(
                     children: <Widget>[
+                      // Align(
+                      //   alignment: Alignment.topRight,
+                      //   child: Icon(
+                      //     Icons.fiber_manual_record_rounded,
+                      //     color: (unseen &&
+                      //             (lastMessageSender != loggedInUser.uid))
+                      //         ? Colors.lightGreen
+                      //         : Colors.cyan,
+                      //   ),
+                      // ),
                       CircleAvatar(
                         radius: 30.0,
                         backgroundColor: Colors.white,
@@ -177,8 +188,17 @@ class ConversationBubble extends StatelessWidget {
                                   overflow: TextOverflow.ellipsis,
                                   style: TextStyle(
                                       color: Colors.white,
-                                      fontStyle: FontStyle.italic,
-                                      fontSize: 16)),
+                                      fontStyle: (unseen &&
+                                              (lastMessageSender !=
+                                                  loggedInUser.uid))
+                                          ? FontStyle.italic
+                                          : FontStyle.normal,
+                                      fontSize: 16,
+                                      fontWeight: (unseen &&
+                                              (lastMessageSender !=
+                                                  loggedInUser.uid))
+                                          ? FontWeight.bold
+                                          : FontWeight.normal)),
                               alignment: Alignment.centerLeft,
                               margin: EdgeInsets.fromLTRB(10.0, 0.0, 0.0, 10.0),
                             ),
@@ -190,7 +210,7 @@ class ConversationBubble extends StatelessWidget {
                         child: Icon(
                           Icons.fiber_manual_record_rounded,
                           color: (unseen &&
-                                  (lastMessageSender == loggedInUser.uid))
+                                  (lastMessageSender != loggedInUser.uid))
                               ? Colors.white
                               : Colors.cyan,
                         ),

--- a/lib/screens/chat_screens/user_chats.dart
+++ b/lib/screens/chat_screens/user_chats.dart
@@ -209,7 +209,8 @@ class ConversationBubble extends StatelessWidget {
                         child: Icon(
                           Icons.fiber_manual_record_rounded,
                           color: (unseen &&
-                                  (lastMessageSender != loggedInUser.uid))
+                                  (lastMessageSender != loggedInUser.uid) &&
+                                  !enteredChat)
                               ? Colors.white
                               : Colors.cyan,
                         ),

--- a/lib/screens/chat_screens/user_chats.dart
+++ b/lib/screens/chat_screens/user_chats.dart
@@ -108,7 +108,6 @@ class ConversationBubble extends StatelessWidget {
     this.unseen,
     this.groupId,
     this.lastMessageSender,
-    this.enteredChat,
   });
   final String recipientId;
   final String questionTitle;
@@ -116,7 +115,6 @@ class ConversationBubble extends StatelessWidget {
   final bool unseen;
   final String groupId;
   final String lastMessageSender;
-  final bool enteredChat;
 
   @override
   Widget build(BuildContext context) {
@@ -154,7 +152,6 @@ class ConversationBubble extends StatelessWidget {
                                       snapshot.data.lastName,
                                   questionId: questionId,
                                   lastMessageSender: lastMessageSender,
-                                  enteredChat: enteredChat,
                                 )));
                   },
                   child: Row(

--- a/lib/screens/chat_screens/user_chats.dart
+++ b/lib/screens/chat_screens/user_chats.dart
@@ -67,8 +67,7 @@ class ConversationsStream extends StatelessWidget {
           final unseen = userChat.data()['unseen'];
           final groupChatID = userChat.data()['groupChatId'];
           final lastMessageSender = userChat.data()['lastMessageSender'];
-          final meInTheRoom = userChat.data()[loggedInUser.uid];
-          final recipientInTheRoom = userChat.data()[recipientID];
+
           //if the user has not seen this message, then this will be true
           final conversationBubble = ConversationBubble(
             questionTitle: questionTitle,
@@ -79,7 +78,6 @@ class ConversationsStream extends StatelessWidget {
             unseen: unseen,
             groupId: groupChatID,
             lastMessageSender: lastMessageSender,
-            enteredChat: enteredChat,
           );
           if (conversationUserID == loggedInUser.uid ||
               recipientID == loggedInUser.uid) {
@@ -120,7 +118,6 @@ class ConversationBubble extends StatelessWidget {
   final String lastMessageSender;
   final bool enteredChat;
 
-
   @override
   Widget build(BuildContext context) {
     return FutureBuilder<UserModel>(
@@ -137,7 +134,7 @@ class ConversationBubble extends StatelessWidget {
                     borderRadius: BorderRadius.all(Radius.circular(25.0))),
                 child: FlatButton(
                   onPressed: () {
-                    if(unseen && lastMessageSender != loggedInUser.uid) {
+                    if (unseen && lastMessageSender != loggedInUser.uid) {
                       _firestore
                           .collection('messages')
                           .doc(groupId)
@@ -198,8 +195,7 @@ class ConversationBubble extends StatelessWidget {
                                       fontSize: 16,
                                       fontWeight: (unseen &&
                                               (lastMessageSender !=
-                                                  loggedInUser.uid) &&
-                                              !enteredChat)
+                                                  loggedInUser.uid))
                                           ? FontWeight.bold
                                           : FontWeight.normal)),
                               alignment: Alignment.centerLeft,
@@ -213,8 +209,7 @@ class ConversationBubble extends StatelessWidget {
                         child: Icon(
                           Icons.fiber_manual_record_rounded,
                           color: (unseen &&
-                                  (lastMessageSender != loggedInUser.uid) &&
-                                  !enteredChat)
+                                  (lastMessageSender != loggedInUser.uid))
                               ? Colors.white
                               : Colors.cyan,
                         ),

--- a/lib/screens/chat_screens/user_chats.dart
+++ b/lib/screens/chat_screens/user_chats.dart
@@ -64,12 +64,18 @@ class ConversationsStream extends StatelessWidget {
           final recipientID = userChat.data()['recipientId'];
           final questionTitle = userChat.data()['questionTitle'];
           final questionID = userChat.data()['questionId'];
+          final unseen = userChat.data()['unseen'];
+          final groupChatID = userChat.data()['groupChatId'];
+          final lastMessageSender = userChat.data()['lastMessageSender'];
+          //if the user has not seen this message, then this will be true
           final conversationBubble = ConversationBubble(
             questionTitle: questionTitle,
             recipientId: recipientID == loggedInUser.uid
                 ? conversationUserID
                 : recipientID,
             questionId: questionID,
+            unseen: unseen,
+            groupId: groupChatID,
           );
           if (conversationUserID == loggedInUser.uid ||
               recipientID == loggedInUser.uid) {
@@ -93,10 +99,20 @@ Future<UserModel> initGetUserDetails(recipientId) async {
 }
 
 class ConversationBubble extends StatelessWidget {
-  ConversationBubble({this.recipientId, this.questionTitle, this.questionId});
+  ConversationBubble({
+    this.recipientId,
+    this.questionTitle,
+    this.questionId,
+    this.unseen,
+    this.groupId,
+    this.lastMessageSender,
+  });
   final String recipientId;
   final String questionTitle;
   final String questionId;
+  final bool unseen;
+  final String groupId;
+  final String lastMessageSender;
 
   @override
   Widget build(BuildContext context) {
@@ -114,6 +130,13 @@ class ConversationBubble extends StatelessWidget {
                     borderRadius: BorderRadius.all(Radius.circular(25.0))),
                 child: FlatButton(
                   onPressed: () {
+                    print(recipientId);
+                    print(loggedInUser.uid);
+                    _firestore
+                        .collection('messages')
+                        .doc(groupId)
+                        .update({'unseen': false});
+
                     Navigator.push(
                         context,
                         MaterialPageRoute(
@@ -161,7 +184,17 @@ class ConversationBubble extends StatelessWidget {
                             ),
                           ],
                         ),
-                      )
+                      ),
+                      Align(
+                        alignment: Alignment.topRight,
+                        child: Icon(
+                          Icons.fiber_manual_record_rounded,
+                          color: (unseen &&
+                                  (lastMessageSender == loggedInUser.uid))
+                              ? Colors.white
+                              : Colors.cyan,
+                        ),
+                      ),
                     ],
                   ),
                 ),

--- a/lib/screens/more_details_page.dart
+++ b/lib/screens/more_details_page.dart
@@ -77,7 +77,6 @@ class _MoreDetailsState extends State<MoreDetails> {
               fromId: _moreDetailModel.user.id,
               recipient: _moreDetailModel.user.firstName,
               questionId: _moreDetailModel.question.id,
-              enteredChat: true,
             ),
           ),
         );

--- a/lib/screens/more_details_page.dart
+++ b/lib/screens/more_details_page.dart
@@ -77,6 +77,7 @@ class _MoreDetailsState extends State<MoreDetails> {
               fromId: _moreDetailModel.user.id,
               recipient: _moreDetailModel.user.firstName,
               questionId: _moreDetailModel.question.id,
+              enteredChat: true,
             ),
           ),
         );
@@ -117,6 +118,7 @@ class _MoreDetailsState extends State<MoreDetails> {
       'lastMessageSender': currUserId,
       'unseen': true,
       'groupChatId': groupChatId,
+      'enteredChat': true,
       //this was include to change the unseen field to false once the message has been seen.
     });
   }

--- a/lib/screens/more_details_page.dart
+++ b/lib/screens/more_details_page.dart
@@ -117,6 +117,8 @@ class _MoreDetailsState extends State<MoreDetails> {
       'lastMessageSender': currUserId,
       'unseen': true,
       'groupChatId': groupChatId,
+      currUserId: false,
+      _moreDetailModel.user.id: false,
       //this was include to change the unseen field to false once the message has been seen.
     });
   }

--- a/lib/screens/more_details_page.dart
+++ b/lib/screens/more_details_page.dart
@@ -15,6 +15,7 @@ import 'package:project_eureka_flutter/services/email_auth.dart';
 import 'package:project_eureka_flutter/services/more_detail_service.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:project_eureka_flutter/screens/chat_screens/chat_screen.dart';
+import 'package:project_eureka_flutter/services/users_service.dart';
 
 final _firestore = FirebaseFirestore.instance;
 User loggedInUser = EmailAuth().getCurrentUser();

--- a/lib/screens/more_details_page.dart
+++ b/lib/screens/more_details_page.dart
@@ -114,6 +114,10 @@ class _MoreDetailsState extends State<MoreDetails> {
       'questionTitle': _moreDetailModel.question.title,
       'questionId': _moreDetailModel.question.id,
       'timestamp': DateTime.now(),
+      'lastMessageSender': currUserId,
+      'unseen': true,
+      'groupChatId': groupChatId,
+      //this was include to change the unseen field to false once the message has been seen.
     });
   }
 


### PR DESCRIPTION
What I did:

- When a user receives a new messages, a notification should pop up over the conversation in the user chats page. It will be signified by a white circle icon appearing in the right side of the bubble, like so 
![Screen Shot 2021-05-02 at 3 25 49 PM](https://user-images.githubusercontent.com/48227740/116829783-ae068000-ab5a-11eb-83d1-a805a012d6ab.png)

- When a there is no new message, then, no circle icon will be seen

How To Test:

- checkout to my branch, PE-103, git fetch and git pull.
- Run the application on your emulator of choice.
- Find the question labeled "Use This Question to test PE-103" and start a new conversation by messaging David
- Send a message.
- Notify me that you have sent a message, and I will check on my end. If I see the new message notification, then the component is successful
- I wil then send you a message, and you should see the new message notification show up in your user chats screen. 
![Screen Shot 2021-05-02 at 3 30 36 PM](https://user-images.githubusercontent.com/48227740/116829876-59afd000-ab5b-11eb-9836-cb208525a67d.png)

- If you can see the white circle in your user chats page, then receiving the notification after a new message sent is successful.
- Test for the same results by starting a call and have me start a call. We both should see a new message notification afterwards. 
 
