### PR TITLE
PE-109 | Added profile buttons and ratings in more details page

### DIFF
--- a/lib/components/more_details_view.dart
+++ b/lib/components/more_details_view.dart
@@ -4,6 +4,7 @@ import 'package:project_eureka_flutter/models/more_details_model.dart';
 import 'package:project_eureka_flutter/models/user_answer_model.dart';
 import 'package:project_eureka_flutter/screens/home_screen.dart';
 import 'package:project_eureka_flutter/screens/new_form_screens/new_form.dart';
+import 'package:project_eureka_flutter/screens/profile_screen.dart';
 import 'package:project_eureka_flutter/services/close_question_service.dart';
 import 'package:timeago/timeago.dart' as timeago;
 
@@ -27,24 +28,29 @@ class _MoreDetailsViewState extends State<MoreDetailsView> {
   Padding profileIcon() {
     return Padding(
       padding: const EdgeInsets.fromLTRB(0.0, 10.0, 15.0, 0.0),
-      child: CircleAvatar(
-        radius: widget.isAnswer ? 20.0 : 40.0,
-        backgroundColor: Colors.transparent,
-        backgroundImage: (widget.isAnswer
-                ? widget.userAnswerModel.user.pictureUrl == ''
-                : widget.moreDetailModel.user.pictureUrl == '')
-            ? AssetImage('assets/images/profile_default_image.png')
-            : NetworkImage(
-                widget.isAnswer
-                    ? widget.userAnswerModel.user.pictureUrl
-                    : widget.moreDetailModel.user.pictureUrl,
-              ),
+      child: GestureDetector(
+        onTap: () async { Navigator.push(context,
+            MaterialPageRoute(builder: (BuildContext context) => Profile(isMoreDetailsPage: true, userId: widget.isAnswer ? widget.userAnswerModel.user.id : widget.moreDetailModel.user.id,))); },
+        child: CircleAvatar(
+          radius: widget.isAnswer ? 20.0 : 40.0,
+          backgroundColor: Colors.transparent,
+          backgroundImage: (widget.isAnswer
+                  ? widget.userAnswerModel.user.pictureUrl == ''
+                  : widget.moreDetailModel.user.pictureUrl == '')
+              ? AssetImage('assets/images/profile_default_image.png')
+              : NetworkImage(
+                  widget.isAnswer
+                      ? widget.userAnswerModel.user.pictureUrl
+                      : widget.moreDetailModel.user.pictureUrl,
+                ),
+        ),
       ),
     );
   }
 
   Row _profileName() {
     return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
         Text(
           widget.isAnswer
@@ -55,6 +61,13 @@ class _MoreDetailsViewState extends State<MoreDetailsView> {
               fontWeight: FontWeight.bold),
           textAlign: TextAlign.left,
         ),
+
+        if (widget.isAnswer)
+          widget.userAnswerModel.user.averageRating == 0.0
+              ? Text("  Not rated yet ⭐")
+              : Text("  " +
+            widget.userAnswerModel.user.averageRating.toString() + " ⭐",
+          ),
       ],
     );
   }
@@ -118,6 +131,12 @@ class _MoreDetailsViewState extends State<MoreDetailsView> {
           children: [
             SizedBox(height: 15.0),
             _profileName(),
+            if (!widget.isAnswer)
+              widget.moreDetailModel.user.averageRating == 0.0
+                  ? Text("Not rated yet ⭐")
+                  : Text(
+                widget.moreDetailModel.user.averageRating.toString() + " ⭐",
+              ),
             SizedBox(height: widget.isAnswer ? 0.0 : 10.0),
             _questionCategory(),
             _timeAgo(dateTime),

--- a/lib/components/side_menu.dart
+++ b/lib/components/side_menu.dart
@@ -26,6 +26,7 @@ class _SideMenuState extends State<SideMenu> {
     email: '',
     pictureUrl: '',
   );
+  String userId = EmailAuth().getCurrentUser().uid;
 
   @override
   void initState() {
@@ -34,7 +35,6 @@ class _SideMenuState extends State<SideMenu> {
   }
 
   void initGetCurrentUser() {
-    String userId = EmailAuth().getCurrentUser().uid;
 
     UserService().getUserById(userId).then((payload) {
       setState(() {
@@ -76,7 +76,7 @@ class _SideMenuState extends State<SideMenu> {
           sideMenuListTile(
             context,
             'Profile',
-            Profile(),
+            Profile(userId: userId),
             Icons.person,
           ),
           Divider(color: Colors.grey.shade400, height: 1.0),

--- a/lib/screens/more_details_page.dart
+++ b/lib/screens/more_details_page.dart
@@ -59,7 +59,7 @@ class _MoreDetailsState extends State<MoreDetails> {
       onPressed: () {
         addChatToFirebase();
 
-        Navigator.push(
+        Navigator.pushReplacement(
           context,
           MaterialPageRoute(
             builder: (context) => ChatScreen(

--- a/lib/screens/more_details_page.dart
+++ b/lib/screens/more_details_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter/painting.dart';
 import 'package:project_eureka_flutter/components/eureka_appbar.dart';
 import 'package:project_eureka_flutter/components/eureka_rounded_button.dart';
 import 'package:project_eureka_flutter/components/more_details_view.dart';
+import 'package:project_eureka_flutter/components/side_menu.dart';
 import 'package:project_eureka_flutter/models/more_details_model.dart';
 import 'package:project_eureka_flutter/models/question_model.dart';
 import 'package:project_eureka_flutter/models/user_answer_model.dart';
@@ -19,9 +20,11 @@ final _firestore = FirebaseFirestore.instance;
 
 class MoreDetails extends StatefulWidget {
   final String questionId;
+  final bool isCreatedOrAnswered;
 
   MoreDetails({
     this.questionId,
+    this.isCreatedOrAnswered
   });
 
   @override
@@ -189,9 +192,16 @@ class _MoreDetailsState extends State<MoreDetails> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      drawer: SideMenu(),
       appBar: EurekaAppBar(
         title: 'Question Details',
         appBar: AppBar(),
+         actions: widget.isCreatedOrAnswered == null ? [IconButton(
+              icon: Icon(
+                Icons.arrow_back_outlined,
+                color: Colors.white,
+              ),
+              onPressed: () => Navigator.pop(context)), SizedBox(width: 15)] : null
       ),
       body: SingleChildScrollView(
         child: Container(

--- a/lib/screens/new_form_screens/new_form_confirmation.dart
+++ b/lib/screens/new_form_screens/new_form_confirmation.dart
@@ -151,6 +151,7 @@ class _NewFormConfirmationState extends State<NewFormConfirmation> {
                     builder: (context) => MoreDetails(
                       questionId:
                       widget.isAnswer ? widget.answerModel.questionId : widget.questionModel.id,
+                      isCreatedOrAnswered: true,
                     ),
                   ),
                 ),

--- a/lib/screens/profile_onboarding_screen.dart
+++ b/lib/screens/profile_onboarding_screen.dart
@@ -43,16 +43,6 @@ class _ProfileOnboardingState extends State<ProfileOnboarding> {
     return EurekaAppBar(
       title: widget.isProfile ? 'Edit Your Profile' : 'Create Your Profile',
       appBar: AppBar(),
-      actions: [
-        widget.isProfile
-            ? IconButton(
-                icon: Icon(
-                  Icons.cancel,
-                  color: Color(0xFF00ADB5),
-                ),
-                onPressed: () => Navigator.pop(context))
-            : Container(),
-      ],
     );
   }
 

--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -11,6 +11,12 @@ import 'package:project_eureka_flutter/services/profile_service.dart';
 import 'package:project_eureka_flutter/components/side_menu.dart';
 
 class Profile extends StatefulWidget {
+
+  final isMoreDetailsPage;
+  final userId;
+
+  Profile({this.userId, this.isMoreDetailsPage});
+
   @override
   _ProfileState createState() => _ProfileState();
 }
@@ -23,7 +29,7 @@ class _ProfileState extends State<Profile> {
   List categories = [];
   bool loading = true;
 
-  final User user = EmailAuth().getCurrentUser();
+  final User currentUser = EmailAuth().getCurrentUser();
 
   @override
   void initState() {
@@ -32,7 +38,7 @@ class _ProfileState extends State<Profile> {
   }
 
   void initGetProfileData() {
-    ProfileService().getProfileInformation(user.uid).then(
+    ProfileService().getProfileInformation(widget.isMoreDetailsPage == null ? currentUser.uid : widget.userId).then(
       (payload) {
         setState(() {
           questionsList = payload[0];
@@ -124,6 +130,7 @@ class _ProfileState extends State<Profile> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.end,
         children: [
+          if (widget.userId == currentUser.uid)
           _editProfileButton(),
           SizedBox(
             height: 15.0,
@@ -226,7 +233,7 @@ class _ProfileState extends State<Profile> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      drawer: SideMenu(),
+      drawer: widget.isMoreDetailsPage == null ? SideMenu() : null,
       body: Column(
         children: [
           _headerStack(),

--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -158,6 +158,12 @@ class _ProfileState extends State<Profile> {
         EurekaAppBar(
           title: 'Profile',
           appBar: AppBar(),
+          actions: widget.isMoreDetailsPage == null ? null : [IconButton(
+              icon: Icon(
+                Icons.arrow_back_outlined,
+                color: Colors.white,
+              ),
+              onPressed: () => Navigator.pop(context)), SizedBox(width: 15)],
         ),
         _profileNameAndIcon(),
         _editButtonAndRating(),
@@ -233,7 +239,7 @@ class _ProfileState extends State<Profile> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      drawer: widget.isMoreDetailsPage == null ? SideMenu() : null,
+      drawer: SideMenu(),
       body: Column(
         children: [
           _headerStack(),


### PR DESCRIPTION
What I Did:
- Added profile link to the profile picture on the more details page
- Added ratings to be displayed on the more details page

How to Test:
- Go to more details
- Ratings on the screen must correspond to the user rating. If no rated, it must show Not Rated Yet
- Profile images must be responsive and bring the user to the profile of the clicked user. If the user clicked on the own profile, the user will see the Edit Profile button, otherwise, it must not show up