### PR TITLE
PE-110 | Changed Back Button to Home Button

### DIFF
--- a/lib/screens/more_details_page.dart
+++ b/lib/screens/more_details_page.dart
@@ -189,19 +189,19 @@ class _MoreDetailsState extends State<MoreDetails> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      drawer: SideMenu(),
       appBar: EurekaAppBar(
           title: 'Question Details',
           appBar: AppBar(),
           actions: widget.isCreatedOrAnswered == null
               ? [
-                  IconButton(
-                      icon: Icon(
-                        Icons.arrow_back_outlined,
-                        color: Colors.white,
-                      ),
-                      onPressed: () => Navigator.pop(context)),
-                  SizedBox(width: 15)
+            IconButton(
+                icon: Icon(
+                  Icons.home,
+                  color: Colors.white,
+                ),
+                onPressed: () => Navigator.pushNamedAndRemoveUntil(
+                    context, '/home', (Route<void> route) => false)),
+            SizedBox(width: 15)
                 ]
               : null),
       body: SingleChildScrollView(

--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -130,8 +130,8 @@ class _ProfileState extends State<Profile> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.end,
         children: [
-          if (widget.userId == currentUser.uid)
-          _editProfileButton(),
+          if ((widget.userId == currentUser.uid) | (widget.userId == null))
+            _editProfileButton(),
           SizedBox(
             height: 15.0,
           ),
@@ -158,12 +158,18 @@ class _ProfileState extends State<Profile> {
         EurekaAppBar(
           title: 'Profile',
           appBar: AppBar(),
-          actions: widget.isMoreDetailsPage == null ? null : [IconButton(
-              icon: Icon(
-                Icons.arrow_back_outlined,
-                color: Colors.white,
-              ),
-              onPressed: () => Navigator.pop(context)), SizedBox(width: 15)],
+          actions: widget.isMoreDetailsPage == null
+              ? null
+              : [
+                  IconButton(
+                      icon: Icon(
+                        Icons.home,
+                        color: Colors.white,
+                      ),
+                      onPressed: () => Navigator.pushNamedAndRemoveUntil(
+                          context, '/home', (Route<void> route) => false)),
+                  SizedBox(width: 15)
+                ],
         ),
         _profileNameAndIcon(),
         _editButtonAndRating(),
@@ -239,7 +245,7 @@ class _ProfileState extends State<Profile> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      drawer: SideMenu(),
+      drawer: widget.isMoreDetailsPage == null ? SideMenu() : null,
       body: Column(
         children: [
           _headerStack(),


### PR DESCRIPTION
What I Did:
- Now Back button is not on the left (based on the side menu, not hardcoded with .pop anymore) and the Home button shows up on the right on More Details and Profile screens

How to Test:
- Walkthrough the routes and check if everything shows up as intended. 
- Edit profile button must show up only on the user's own profile page
- After the profile is edited, regardless of where the user clicked Edit Profile, on the updated profile screen user must only see a side menu button