### PR TITLE
PE-113 | Small changes to Login screens

### DIFF
--- a/lib/screens/forgot_password.dart
+++ b/lib/screens/forgot_password.dart
@@ -57,7 +57,8 @@ class _ForgotpasswordState extends State<ForgotPassword> {
                   borderSide: BorderSide(color: Colors.grey[200]),
                 ),
                 prefixIcon: Icon(Icons.email),
-                labelText: 'Email',
+                hintText: 'Email',
+                border: const OutlineInputBorder(),
               ),
               onSaved: (value) {
                 setState(() {

--- a/lib/screens/signin_screen.dart
+++ b/lib/screens/signin_screen.dart
@@ -309,43 +309,41 @@ class _SignInState extends State<SignIn> {
           child: Stack(
             fit: StackFit.expand,
             children: <Widget>[
-              Expanded(
-                child: Padding(
-                  padding: EdgeInsets.only(
-                    left: 25,
-                    right: 25,
-                    top: 120,
-                  ),
-                  child: Column(
-                    children: <Widget>[
-                      Text(
-                        'Sign In',
+              Padding(
+                padding: EdgeInsets.only(
+                  left: 25,
+                  right: 25,
+                  top: 120,
+                ),
+                child: Column(
+                  children: <Widget>[
+                    Text(
+                      'Sign In',
+                      style: TextStyle(
+                        fontSize: 40.0,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    SizedBox(height: 40.0),
+                    _loginTextForm(context),
+                    Visibility(
+                      visible: exception == "" ? false : true,
+                      child: Text(
+                        exception,
                         style: TextStyle(
-                          fontSize: 40.0,
-                          fontWeight: FontWeight.bold,
+                          color: Colors.red,
                         ),
                       ),
-                      SizedBox(height: 40.0),
-                      _loginTextForm(context),
-                      Visibility(
-                        visible: exception == "" ? false : true,
-                        child: Text(
-                          exception,
-                          style: TextStyle(
-                            color: Colors.red,
-                          ),
-                        ),
-                      ),
-                      _forgotPasswordButton(context),
-                      SizedBox(height: 30.0),
-                      _loginButton(context),
-                      _signUpButton(context),
-                      SizedBox(height: 20.0),
-                      _orLoginWith(),
-                      SizedBox(height: 10.0),
-                      _googleSignInButton(context),
-                    ],
-                  ),
+                    ),
+                    _forgotPasswordButton(context),
+                    SizedBox(height: 30.0),
+                    _loginButton(context),
+                    _signUpButton(context),
+                    SizedBox(height: 20.0),
+                    _orLoginWith(),
+                    SizedBox(height: 10.0),
+                    _googleSignInButton(context),
+                  ],
                 ),
               ),
             ],

--- a/lib/screens/signin_screen.dart
+++ b/lib/screens/signin_screen.dart
@@ -95,7 +95,8 @@ class _SignInState extends State<SignIn> {
             TextFormField(
               keyboardType: TextInputType.emailAddress,
               decoration: InputDecoration(
-                labelText: 'Email',
+                hintText: 'Email',
+                border: const OutlineInputBorder(),
                 filled: true,
                 fillColor: Color(0xF6F6F6F6),
                 enabledBorder: OutlineInputBorder(
@@ -121,7 +122,8 @@ class _SignInState extends State<SignIn> {
             TextFormField(
               obscureText: _isHiddenPassword,
               decoration: InputDecoration(
-                labelText: 'Password',
+                hintText: 'Password',
+                border: const OutlineInputBorder(),
                 filled: true,
                 fillColor: Color(0xF6F6F6F6),
                 enabledBorder: OutlineInputBorder(
@@ -286,6 +288,8 @@ class _SignInState extends State<SignIn> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      resizeToAvoidBottomPadding: false,
+      extendBody: true,
       body: Container(
         decoration: BoxDecoration(
           gradient: LinearGradient(
@@ -305,40 +309,43 @@ class _SignInState extends State<SignIn> {
           child: Stack(
             fit: StackFit.expand,
             children: <Widget>[
-              SingleChildScrollView(
-                padding: EdgeInsets.symmetric(
-                  horizontal: 25,
-                  vertical: 120,
-                ),
-                child: Column(
-                  children: <Widget>[
-                    Text(
-                      'Sign In',
-                      style: TextStyle(
-                        fontSize: 40.0,
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
-                    SizedBox(height: 40.0),
-                    _loginTextForm(context),
-                    Visibility(
-                      visible: exception == "" ? false : true,
-                      child: Text(
-                        exception,
+              Expanded(
+                child: Padding(
+                  padding: EdgeInsets.only(
+                    left: 25,
+                    right: 25,
+                    top: 120,
+                  ),
+                  child: Column(
+                    children: <Widget>[
+                      Text(
+                        'Sign In',
                         style: TextStyle(
-                          color: Colors.red,
+                          fontSize: 40.0,
+                          fontWeight: FontWeight.bold,
                         ),
                       ),
-                    ),
-                    _forgotPasswordButton(context),
-                    SizedBox(height: 30.0),
-                    _loginButton(context),
-                    _signUpButton(context),
-                    SizedBox(height: 20.0),
-                    _orLoginWith(),
-                    SizedBox(height: 10.0),
-                    _googleSignInButton(context),
-                  ],
+                      SizedBox(height: 40.0),
+                      _loginTextForm(context),
+                      Visibility(
+                        visible: exception == "" ? false : true,
+                        child: Text(
+                          exception,
+                          style: TextStyle(
+                            color: Colors.red,
+                          ),
+                        ),
+                      ),
+                      _forgotPasswordButton(context),
+                      SizedBox(height: 30.0),
+                      _loginButton(context),
+                      _signUpButton(context),
+                      SizedBox(height: 20.0),
+                      _orLoginWith(),
+                      SizedBox(height: 10.0),
+                      _googleSignInButton(context),
+                    ],
+                  ),
                 ),
               ),
             ],

--- a/lib/screens/signup_screen.dart
+++ b/lib/screens/signup_screen.dart
@@ -72,7 +72,8 @@ class _SignUpState extends State<SignUp> {
             TextFormField(
               keyboardType: TextInputType.emailAddress,
               decoration: InputDecoration(
-                labelText: 'Email',
+                hintText: 'Email',
+                border: const OutlineInputBorder(),
                 filled: true,
                 fillColor: Color(0xF6F6F6F6),
                 enabledBorder: OutlineInputBorder(
@@ -103,7 +104,8 @@ class _SignUpState extends State<SignUp> {
             TextFormField(
               obscureText: _isHiddenPassword,
               decoration: InputDecoration(
-                labelText: 'Password',
+                hintText: 'Password',
+                border: const OutlineInputBorder(),
                 filled: true,
                 fillColor: Color(0xF6F6F6F6),
                 enabledBorder: OutlineInputBorder(
@@ -139,7 +141,8 @@ class _SignUpState extends State<SignUp> {
             TextFormField(
               obscureText: _isHiddenPassword,
               decoration: InputDecoration(
-                labelText: 'Confirm Password',
+                hintText: 'Confirm Password',
+                border: const OutlineInputBorder(),
                 filled: true,
                 fillColor: Color(0xF6F6F6F6),
                 enabledBorder: OutlineInputBorder(
@@ -214,6 +217,7 @@ class _SignUpState extends State<SignUp> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+        resizeToAvoidBottomPadding: false,
         extendBody: true,
         body: Container(
           decoration: BoxDecoration(


### PR DESCRIPTION
What I Did:
- Made Sign In page non-scrollable
- Change Label to Hint for InputDecoration, and added border while typing (previously only bottom line had border color while typing)
- Fixed: Both Sign In and Sign Up pages had background lifting up when the keyboard opens
- Fixed: Overflow of pixels (after changing to non-scrollable)

How To Test:
- Go through the fields and all possible scenarios to see if any bugs or issues appear